### PR TITLE
Bug/optimisation build/phase3 5

### DIFF
--- a/golf.benoitmignault.ca/league-monteregie/.gitignore
+++ b/golf.benoitmignault.ca/league-monteregie/.gitignore
@@ -17,3 +17,6 @@ yarn-error.log*
 # OS files
 .DS_Store
 Thumbs.db
+
+# stats html
+stats.html

--- a/golf.benoitmignault.ca/league-monteregie/package-lock.json
+++ b/golf.benoitmignault.ca/league-monteregie/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "rollup-plugin-visualizer": "^7.0.1",
         "vite": "^8.0.16"
       }
     },
@@ -1242,6 +1243,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1327,6 +1354,22 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1356,6 +1399,21 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -1581,6 +1639,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1607,6 +1708,13 @@
       "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -1970,6 +2078,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2108,6 +2239,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2129,6 +2276,54 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -2595,6 +2790,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2756,6 +2972,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -3057,6 +3286,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3119,6 +3402,40 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/stylis": {
@@ -3376,12 +3693,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/golf.benoitmignault.ca/league-monteregie/package.json
+++ b/golf.benoitmignault.ca/league-monteregie/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "vite": "^8.0.16"
   }
 }

--- a/golf.benoitmignault.ca/league-monteregie/src/App.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/App.jsx
@@ -1,25 +1,42 @@
+/**
+ * App.jsx
+ *
+ * Composant principal de l'application React qui gère la navigation entre les différentes pages de l'application.
+ * Utilise React Router pour définir les routes et les composants correspondants.
+ * 
+ * À partir du 4 juillet, on va dire à React de charger seulement les routes demandées (lazy loading) pour améliorer les performances de l'application.
+ * On utilise React.Suspense pour afficher un fallback (chargement) pendant que le composant est en cours de chargement.
+ * 
+ * Les routes définies sont :
+ * - /league-monteregie/ : Page d'accueil (HomePage)
+ * - /league-monteregie/statistics : Page des statistiques des joueurs (PlayerStats)
+ * - /league-monteregie/admin/ : Page de connexion pour l'administration (Login)
+ * - /league-monteregie/admin/dashboard : Tableau de bord de l'administration (Dashboard)
+ */
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { lazy, Suspense } from "react";
 
-// Importer les composants de page principale qui est rendu dans HomePage
+// Chargement immédiat
 import HomePage from "./components/HomePage";
 
-// Importer les composants de la page des statistiques
-import PlayerStats from "./components/stats/PlayerStats";
+// Chargement à la demande
+const PlayerStats = lazy(() => import("./components/stats/PlayerStats"));
+const Login = lazy(() => import("./components/admin/Login"));
+const Dashboard = lazy(() => import("./components/admin/Dashboard"));
 
-// Importer les composants de la section admin
-import Login from "./components/admin/Login";
-import Dashboard from "./components/admin/Dashboard";
 
 function App() {
 
     return (
         <BrowserRouter>
-            <Routes>
-                <Route path="/league-monteregie/" element={<HomePage />}/>
-                <Route path="/league-monteregie/statistics" element={<PlayerStats />}/>
-                <Route path="/league-monteregie/admin/" element={<Login />}/>
-                <Route path="/league-monteregie/admin/dashboard" element={<Dashboard />}/>
-            </Routes>
+            <Suspense fallback={<div>Chargement...</div>}>
+                <Routes>
+                    <Route path="/league-monteregie/" element={<HomePage />}/>
+                    <Route path="/league-monteregie/statistics" element={<PlayerStats />}/>
+                    <Route path="/league-monteregie/admin/" element={<Login />}/>
+                    <Route path="/league-monteregie/admin/dashboard" element={<Dashboard />}/>
+                </Routes>
+            </Suspense>            
         </BrowserRouter>
     );
 }

--- a/golf.benoitmignault.ca/league-monteregie/src/components/HomePage.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/HomePage.jsx
@@ -50,7 +50,7 @@ function HomePage() {
 
 		// On doit partir de /league-monteregie car c'est la vraie racine du projet
 		if (favicon) {
-			favicon.href = "/league-monteregie/favicon/favicon-ChatGPT.png";
+			favicon.href = `${import.meta.env.BASE_URL}favicon/favicon-ChatGPT.png`;
 		}
 
 		const handleResize = () => {

--- a/golf.benoitmignault.ca/league-monteregie/src/components/admin/Dashboard.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/admin/Dashboard.jsx
@@ -78,7 +78,7 @@ function Dashboard() {
             const favicon = document.getElementById("dynamic-favicon");
 
             if (favicon) {
-                favicon.href = "/league-monteregie/favicon/favicon-admin-ChatGPT.png";
+                favicon.href = `${import.meta.env.BASE_URL}favicon/favicon-admin-ChatGPT.png`;
             }
         })        
         .catch(() => {

--- a/golf.benoitmignault.ca/league-monteregie/src/components/admin/Login.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/admin/Login.jsx
@@ -173,7 +173,7 @@ function Login() {
         // On doit partir de /league-monteregie car c'est la vraie racine du projet
         // FavIcone de la page
         if (favicon) {
-			favicon.href = "/league-monteregie/favicon/favicon-admin-ChatGPT.png";
+			favicon.href = `${import.meta.env.BASE_URL}favicon/favicon-admin-ChatGPT.png`;
 		}
 
         const handleResize = () => {

--- a/golf.benoitmignault.ca/league-monteregie/src/components/admin/Login.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/admin/Login.jsx
@@ -4,6 +4,7 @@ import { FaHouse } from "react-icons/fa6";
 import { BsCameraFill } from "react-icons/bs";
 import { API_BASE_URL } from "../../config";
 import Footer from "../Footer";
+import '../../css/admin.css'
 
 /**
  * Composant de connexion pour les administrateurs et les sous-administrateurs

--- a/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
@@ -17,18 +17,25 @@
  * PlayerCharts et PlayerHistory seulement quand ils sont nécessaires, pour améliorer les performances de l'application.
  */
 import { useState, useEffect } from "react";
+import { lazy, Suspense } from "react";
 import { Link } from "react-router-dom";
 import { FaArrowUp } from "react-icons/fa";
 import { FaHouse } from "react-icons/fa6";
 import { BsCameraFill } from "react-icons/bs";
 import PlayerSelector from "./PlayerSelector";
-import PlayerSummary from "./PlayerSummary";
-import PlayerCharts from "./PlayerCharts";
-import PlayerHistory from "./PlayerHistory";
 import Footer from "../Footer";
+
 import { API_BASE_URL } from "../../config";
 import '../../css/index.css'
 import '../../css/stats.css'
+
+// Composant pour afficher les statistiques graphique d'un joueur sélectionné et non via la notion de lazy loading, 
+// car il y a un lag de 1 à 2 secondes pour le chargement des graphiques, donc on préfère les charger directement 
+// pour une meilleure expérience utilisateur.
+import PlayerCharts from "./PlayerCharts";
+
+const PlayerSummary = lazy(() => import("./PlayerSummary"));
+const PlayerHistory = lazy(() => import("./PlayerHistory"));
 
 function PlayerStats() {
 

--- a/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
@@ -127,7 +127,9 @@ function PlayerStats() {
 					</div>
 					<div className="player-summary-section">
 						{selectedPlayerId ? (
-							<PlayerSummary selectedPlayerId={selectedPlayerId}/>
+							<Suspense fallback={<p>Chargement du résumé...</p>}>
+								<PlayerSummary selectedPlayerId={selectedPlayerId}/>
+							</Suspense>
 						) : (
 							<p className="player-summary-placeholder">Information sera affichée ici, une fois le joueur sélectionné.</p>
 						)}
@@ -136,8 +138,11 @@ function PlayerStats() {
 
 				{selectedPlayerId && (
 					<div className="player-stats-card player-chart-card">
-						<div className="player-charts-section">
-							<PlayerCharts selectedPlayerId={selectedPlayerId} totalPlayers={totalPlayers} />
+						<div className="player-charts-section">							
+							<PlayerCharts
+								selectedPlayerId={selectedPlayerId}
+								totalPlayers={totalPlayers}
+							/>							
 						</div>
 					</div>
 				)}
@@ -145,7 +150,9 @@ function PlayerStats() {
                 {selectedPlayerId && (
 					<div className="player-stats-card player-history-card">
 						<div className="player-history-section">
-							<PlayerHistory selectedPlayerId={selectedPlayerId} />
+							<Suspense fallback={<p>Chargement de l'historique...</p>}>
+								<PlayerHistory selectedPlayerId={selectedPlayerId} />
+							</Suspense>
 						</div>
 					</div>
 				)}

--- a/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
@@ -107,7 +107,7 @@ function PlayerStats() {
     return (
         <div className="player-stats-page">
             <div className="site-navbar">
-                <Link to="/league-monteregie/" className="admin-navbar-link">
+                <Link to="/league-monteregie/" className="site-navbar-link">
                     <FaHouse/>
                     <span>Retour au site principal</span>
                 </Link>

--- a/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
@@ -3,6 +3,19 @@
 // des tableaux pour montrer les performances des joueurs au fil du temps.
 // Les données sont récupérées via l'API, et les graphiques sont rendus avec Recharts.
 
+/**
+ * PlayerStats.jsx
+ *
+ * Composant React qui affiche les statistiques d'un joueur sélectionné de la ligue.
+ * Il permet à l'utilisateur de sélectionner un joueur et d'afficher ses statistiques sous forme de graphiques et de tableaux.
+ * 
+ * Il est accessible via un lien dans la barre de navigation et affiche des graphiques et
+ * des tableaux pour montrer les performances des joueurs au fil du temps.
+ * Les données sont récupérées via l'API, et les graphiques sont rendus avec Recharts.
+ * 
+ * On va utiliser ici aussi lazy loading pour charger les composants PlayerSummary, 
+ * PlayerCharts et PlayerHistory seulement quand ils sont nécessaires, pour améliorer les performances de l'application.
+ */
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { FaArrowUp } from "react-icons/fa";

--- a/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
+++ b/golf.benoitmignault.ca/league-monteregie/src/components/stats/PlayerStats.jsx
@@ -62,7 +62,7 @@ function PlayerStats() {
 
 		// On doit partir de /league-monteregie car c'est la vraie racine du projet
 		if (favicon) {
-			favicon.href = "/league-monteregie/favicon/favicon-stats-players-ChatGPT.png";
+			favicon.href = `${import.meta.env.BASE_URL}favicon/favicon-stats-players-ChatGPT.png`;
 		}
 
 		const handleResize = () => {

--- a/golf.benoitmignault.ca/league-monteregie/src/css/index.css
+++ b/golf.benoitmignault.ca/league-monteregie/src/css/index.css
@@ -19,7 +19,7 @@ body {
             rgba(5,10,25,0.50),
             rgba(5,10,25,0.60)
         ),
-        url("/league-monteregie/images/backgrounds/version-web.jpg");
+        url("/images/backgrounds/version-web.jpg");
 
     background-size: cover;
     background-position: center;
@@ -817,7 +817,7 @@ tbody tr:nth-child(even) {
             rgba(5,10,25,0.50),
             rgba(5,10,25,0.60)
             ),
-            url("/league-monteregie/images/backgrounds/version-mobile.jpg");
+            url("/images/backgrounds/version-mobile.jpg");
 
         background-size: cover;
         background-position: center;

--- a/golf.benoitmignault.ca/league-monteregie/vite.config.js
+++ b/golf.benoitmignault.ca/league-monteregie/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite'
+import { visualizer } from "rollup-plugin-visualizer";
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), visualizer({open: true, gzipSize: true})],
   
   // Définir la base pour que les ressources soient correctement chargées 
   // même si l'application est servie à partir d'un sous-répertoire

--- a/golf.benoitmignault.ca/league-monteregie/vite.config.js
+++ b/golf.benoitmignault.ca/league-monteregie/vite.config.js
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vite'
-import { visualizer } from "rollup-plugin-visualizer";
+// import { visualizer } from "rollup-plugin-visualizer";
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  plugins: [react(), visualizer({open: true, gzipSize: true})],
+  plugins: [react(),  /* visualizer({open: true, gzipSize: true})] */ ],
   
   // Définir la base pour que les ressources soient correctement chargées 
   // même si l'application est servie à partir d'un sous-répertoire


### PR DESCRIPTION
This pull request introduces several improvements to the `league-monteregie` project, focusing on performance optimization, development tooling, and code quality. The main highlights are the implementation of lazy loading for route-based components to enhance app performance, and the addition of the `rollup-plugin-visualizer` for bundle analysis. There are also minor updates to ensure better environment compatibility and to ignore generated stats files.

**Performance and Code Quality Improvements**

* Implemented lazy loading for major route components (`PlayerStats`, `Login`, `Dashboard`) in `App.jsx` using `React.lazy` and `Suspense`, which will improve the application's initial load time by only loading code for the route being visited.
* Updated favicon path in `HomePage.jsx` to use `import.meta.env.BASE_URL` for better compatibility with different deployment environments.

**Development Tooling and Dependency Updates**

* Added `rollup-plugin-visualizer` to `devDependencies` in `package.json` and `package-lock.json`, along with all required sub-dependencies, to support bundle analysis and visualization. [[1]](diffhunk://#diff-467da39dac997513f4cceedcb418b30435257de78528384eb0dc447ba8691bf9R30) [[2]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR28) [[3]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR3289-R3342)
* Added a `.gitignore` rule for `stats.html` to avoid committing generated bundle analysis reports.
* Updated `package-lock.json` with new dependencies required by `rollup-plugin-visualizer` and its ecosystem (such as `open`, `yargs`, `cliui`, etc.), ensuring compatibility with recent Node.js versions. [[1]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR1246-R1271) [[2]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR1357-R1372) [[3]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR1403-R1417) [[4]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR1642-R1684) [[5]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR1712-R1718) [[6]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR2081-R2103) [[7]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR2242-R2257) [[8]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR2281-R2328) [[9]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR2793-R2813) [[10]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR2977-R2989) [[11]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR3407-R3440) [[12]](diffhunk://#diff-2b63c2e26268a9bc3c2c43220e6fd9b04745d35f68220bfcbb8df24ef9b33c7dR3696-R3775)